### PR TITLE
call parent::__construct($e);

### DIFF
--- a/src/Pure/Exception/VirgilCloudStorageException.php
+++ b/src/Pure/Exception/VirgilCloudStorageException.php
@@ -58,6 +58,8 @@ class VirgilCloudStorageException extends PureStorageException
      */
     public function __construct($e)
     {
+        parent::__construct($e);
+        
         $this->protocolException = null;
         $this->protocolHttpException = null;
 


### PR DESCRIPTION
otherwise message is not properly assigned and the exception is not readable